### PR TITLE
Change the default implementation of `SessionPersistable` to store with a key based on the objects type

### DIFF
--- a/Sources/AuthProvider/SessionPersistable.swift
+++ b/Sources/AuthProvider/SessionPersistable.swift
@@ -15,15 +15,15 @@ private let sessionEntityId = "session-entity-id"
 
 extension SessionPersistable where Self: Entity {
     public func persist(for req: Request) throws {
-        try req.session().data.set(sessionEntityId, id)
+        try req.session().data.set(sessionEntityId + "-\(Self.self)", id)
     }
     
     public func unpersist(for req: Request) throws {
-        try req.session().data.set(sessionEntityId, nil)
+        try req.session().data.set(sessionEntityId + "-\(Self.self)", nil)
     }
     
     public static func fetchPersisted(for request: Request) throws -> Self? {
-        guard let id = try request.session().data[sessionEntityId] else {
+        guard let id = try request.session().data[sessionEntityId + "-\(Self.self)"] else {
             return nil
         }
         


### PR DESCRIPTION
Fixes #7 