### PR TITLE
Make BCryptHasher conform to PasswordVerifier

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@
 /Packages
 /*.xcodeproj
 Package.pins
-
+DerivedData/

--- a/Sources/AuthProvider/BCrypt+PasswordVerifier.swift
+++ b/Sources/AuthProvider/BCrypt+PasswordVerifier.swift
@@ -1,0 +1,7 @@
+import Vapor
+
+extension BCryptHasher: PasswordVerifier {
+    public func verify(password: String, matchesHash: String) throws -> Bool {
+        return try check(password.bytes, matchesHash: matchesHash.bytes)
+    }
+}

--- a/Sources/AuthProvider/BCrypt+PasswordVerifier.swift
+++ b/Sources/AuthProvider/BCrypt+PasswordVerifier.swift
@@ -1,7 +1,7 @@
 import Vapor
 
 extension BCryptHasher: PasswordVerifier {
-    public func verify(password: String, matchesHash: String) throws -> Bool {
-        return try check(password.bytes, matchesHash: matchesHash.bytes)
+    public func verify(password: Bytes, matches hash: Bytes) throws -> Bool {
+        return try check(password, matchesHash: hash)
     }
 }


### PR DESCRIPTION
Makes using BCrypt easier with the Auth package. This PR will obviously need to be updated when the PasswordVerifier signature is changed as part of the [related PR](https://github.com/vapor/auth/pull/6)