### PR TITLE
Make header settable

### DIFF
--- a/Sources/AuthProvider/Helper.swift
+++ b/Sources/AuthProvider/Helper.swift
@@ -10,24 +10,30 @@ public final class Helper {
         self.request = request
     }
 
-    /// Returns the `Authorization: ...` header
+    /// Returns and sets the `Authorization: ...` header
     // from the request.
     public var header: AuthorizationHeader? {
-        guard let authorization = request?.headers["Authorization"] else {
-            guard let query = request?.query else {
-                return nil
+        get {
+            guard let authorization = request?.headers["Authorization"] else {
+                guard let query = request?.query else {
+                    return nil
+                }
+                
+                if let bearer = query["_authorizationBearer"]?.string {
+                    return AuthorizationHeader(string: "Bearer \(bearer)")
+                } else if let basic = query["_authorizationBasic"]?.string {
+                    return AuthorizationHeader(string: "Basic \(basic)")
+                } else {
+                    return nil
+                }
             }
             
-            if let bearer = query["_authorizationBearer"]?.string {
-                return AuthorizationHeader(string: "Bearer \(bearer)")
-            } else if let basic = query["_authorizationBasic"]?.string {
-                return AuthorizationHeader(string: "Basic \(basic)")
-            } else {
-                return nil
-            }
+            return AuthorizationHeader(string: authorization)
         }
-
-        return AuthorizationHeader(string: authorization)
+        
+        set {
+            request?.headers[.authorization] = newValue?.string
+        }
     }
 
     /// Authenticates an `Authenticatable` type.


### PR DESCRIPTION
This is a setter to make setting AuthorizationHeader in a request easier & safer.

This is related to this enhancement proposition: https://github.com/vapor/engine/issues/147

But i've rethought my proposition and i think making these initializers along with making request.auth.header settable in AuthProvider is cleaner. This is what can be done now:

```swift
let credentials = Password(username: username, password: password)
req.auth.header = AuthorizationHeader(basic: credentials)
```

[Pull Request in vapor/auth](https://github.com/vapor/auth/pull/9)